### PR TITLE
Make CMake build script a bit more equivalent to the autotools one

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,18 @@
 cmake_minimum_required(VERSION 3.1)
-project(jpeg C)
 
-add_library(jpeg STATIC)
+# extract version out of configure.ac
+file(READ "configure.ac" CONFIGURE_AC)
+string(REGEX MATCH "AC_INIT\\(\\[libjpeg\\], \\[([0-9.]+)\\]\\)" ver_found "${CONFIGURE_AC}")
+if(NOT ver_found)
+	message(FATAL_ERROR "Could not extract version from configure.ac")
+endif()
+set(LIBJPEG_VERSION "${CMAKE_MATCH_1}")
+
+project(jpeg LANGUAGES C VERSION ${LIBJPEG_VERSION})
+
+include(GNUInstallDirs)
+
+add_library(jpeg)
 target_sources(jpeg PRIVATE
 		jaricom.c jcapimin.c jcapistd.c jcarith.c jccoefct.c jccolor.c
 		jcdctmgr.c jchuff.c jcinit.c jcmainct.c jcmarker.c jcmaster.c
@@ -11,6 +22,12 @@ target_sources(jpeg PRIVATE
 		jdmerge.c jdpostct.c jdsample.c jdtrans.c jerror.c jfdctflt.c
 		jfdctfst.c jfdctint.c jidctflt.c jquant1.c
 		jquant2.c jutils.c jmemmgr.c)
+
+set(jpeg_headers
+	jconfig.h
+	jerror.h
+	jmorecfg.h
+	jpeglib.h)
 
 if (ANDROID)
 	target_sources(jpeg PRIVATE jmem-android.c)
@@ -24,6 +41,15 @@ target_sources(jpeg PRIVATE jidctint.c jidctfst.c)
 # FIXME : include asm for ARM
 # target_sources(jpeg PRIVATE jidctint.c jidctfst.S)
 
-target_compile_definitions(jpeg PRIVATE -DAVOID_TABLES)
+target_compile_definitions(jpeg PRIVATE AVOID_TABLES)
 
-target_include_directories(jpeg PUBLIC .)
+target_include_directories(jpeg PUBLIC
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+	$<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+
+set_target_properties(jpeg PROPERTIES
+	SOVERSION "${PROJECT_VERSION_MAJOR}"
+	VERSION "${PROJECT_VERSION}"
+	PUBLIC_HEADER "${jpeg_headers}")
+
+install(TARGETS jpeg)


### PR DESCRIPTION
- don't force jpeg to build a static library, this allows to dynamically load jpeg by sdl_image
- let cmake install headers + libraries,  equivalent to the autotools project
  If needed, this allows use of e.g. [`FindJPEG`](https://cmake.org/cmake/help/latest/module/FindJPEG.html) in an install prefix created by the cmake project.

Required by https://github.com/libsdl-org/SDL_image/pull/189