### PR TITLE
Support mingw (better)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,7 @@ project(jpeg LANGUAGES C VERSION ${LIBJPEG_VERSION})
 
 include(GNUInstallDirs)
 
-add_library(jpeg)
-target_sources(jpeg PRIVATE
+add_library(jpeg
 		jaricom.c jcapimin.c jcapistd.c jcarith.c jccoefct.c jccolor.c
 		jcdctmgr.c jchuff.c jcinit.c jcmainct.c jcmarker.c jcmaster.c
 		jcomapi.c jcparam.c jcprepct.c jcsample.c jctrans.c jdapimin.c
@@ -60,4 +59,8 @@ if(MINGW AND BUILD_SHARED_LIBS)
 		PREFIX lib)
 endif()
 
-install(TARGETS jpeg)
+install(TARGETS jpeg
+	ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+	RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+	PUBLIC_HEADER DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,14 @@ target_include_directories(jpeg PUBLIC
 set_target_properties(jpeg PROPERTIES
 	SOVERSION "${PROJECT_VERSION_MAJOR}"
 	VERSION "${PROJECT_VERSION}"
-	PUBLIC_HEADER "${jpeg_headers}")
+	PUBLIC_HEADER "${jpeg_headers}"
+	# create libjpeg-9.dll on Windows
+	RUNTIME_OUTPUT_NAME "jpeg-${PROJECT_VERSION_MAJOR}"
+	PREFIX lib)
+
+if(MINGW AND BUILD_SHARED_LIBS)
+	set_target_properties(jpeg PROPERTIES
+		PREFIX lib)
+endif()
 
 install(TARGETS jpeg)


### PR DESCRIPTION
After this pr, a cmake shared build with a mingw compiler creates the following install prefix:
```
cmake_prefix
├── bin
│   └── libjpeg-9.dll
├── include
│   ├── jconfig.h
│   ├── jerror.h
│   ├── jmorecfg.h
│   └── jpeglib.h
└── lib
    └── libjpeg.dll.a
```

For reference, autotool creates the following:
```
autotools_prefix
├── bin
│   ├── cjpeg.exe
│   ├── djpeg.exe
│   ├── jpegtran.exe
│   ├── libjpeg-9.dll
│   ├── rdjpgcom.exe
│   └── wrjpgcom.exe
├── include
│   ├── jconfig.h
│   ├── jerror.h
│   ├── jmorecfg.h
│   └── jpeglib.h
├── lib
│   ├── libjpeg.a
│   ├── libjpeg.dll.a
│   ├── libjpeg.la
│   └── pkgconfig
│       └── libjpeg.pc
└── share
    └── man
        └── man1
            ├── cjpeg.1
            ├── djpeg.1
            ├── jpegtran.1
            ├── rdjpgcom.1
            └── wrjpgcom.1

```